### PR TITLE
S1-L1: Change podSecurityContext to use piccontrol

### DIFF
--- a/s1-l1/content/stream-parameters.properties
+++ b/s1-l1/content/stream-parameters.properties
@@ -450,7 +450,7 @@ deployer.execution-worker-high.kubernetes.requests.cpu=7000m
 deployer.execution-worker-high.kubernetes.limits.memory=4000Mi
 deployer.execution-worker-high.kubernetes.limits.cpu=7000m
 deployer.execution-worker-high.kubernetes.secretKeyRefs=[{ envVarName: 'OBS_USERNAME', secretName: 'obs', dataKey: 'USER_ID' },{ envVarName: 'OBS_PASSWORD', secretName: 'obs', dataKey: 'USER_SECRET' }]
-deployer.execution-worker-high.kubernetes.podSecurityContext={runAsUser: 0, fsGroup: 0}
+deployer.execution-worker-high.kubernetes.podSecurityContext={runAsUser: 1046, fsGroup: 2000}
 deployer.execution-worker-high.kubernetes.volumeMounts=[{ name: 's3-upload-cache', mountPath: '/opt/s3/uploadCache'}]
 deployer.execution-worker-high.kubernetes.volumes=[{ name: 's3-upload-cache', emptyDir: { medium: 'Memory', sizeLimit: '1500Mi' }}]
 
@@ -459,7 +459,7 @@ deployer.execution-worker-medium.kubernetes.requests.cpu=7000m
 deployer.execution-worker-medium.kubernetes.limits.memory=4000Mi
 deployer.execution-worker-medium.kubernetes.limits.cpu=7000m
 deployer.execution-worker-medium.kubernetes.secretKeyRefs=[{ envVarName: 'OBS_USERNAME', secretName: 'obs', dataKey: 'USER_ID' },{ envVarName: 'OBS_PASSWORD', secretName: 'obs', dataKey: 'USER_SECRET' }]
-deployer.execution-worker-medium.kubernetes.podSecurityContext={runAsUser: 0, fsGroup: 0}
+deployer.execution-worker-medium.kubernetes.podSecurityContext={runAsUser: 1046, fsGroup: 2000}
 deployer.execution-worker-medium.kubernetes.volumeMounts=[{ name: 's3-upload-cache', mountPath: '/opt/s3/uploadCache'}]
 deployer.execution-worker-medium.kubernetes.volumes=[{ name: 's3-upload-cache', emptyDir: { medium: 'Memory', sizeLimit: '1500Mi' }}]
 
@@ -468,6 +468,6 @@ deployer.execution-worker-low.kubernetes.requests.cpu=7000m
 deployer.execution-worker-low.kubernetes.limits.memory=4000Mi
 deployer.execution-worker-low.kubernetes.limits.cpu=7000m
 deployer.execution-worker-low.kubernetes.secretKeyRefs=[{ envVarName: 'OBS_USERNAME', secretName: 'obs', dataKey: 'USER_ID' },{ envVarName: 'OBS_PASSWORD', secretName: 'obs', dataKey: 'USER_SECRET' }]
-deployer.execution-worker-low.kubernetes.podSecurityContext={runAsUser: 0, fsGroup: 0}
+deployer.execution-worker-low.kubernetes.podSecurityContext={runAsUser: 1046, fsGroup: 2000}
 deployer.execution-worker-low.kubernetes.volumeMounts=[{ name: 's3-upload-cache', mountPath: '/opt/s3/uploadCache'}]
 deployer.execution-worker-low.kubernetes.volumes=[{ name: 's3-upload-cache', emptyDir: { medium: 'Memory', sizeLimit: '1500Mi' }}]


### PR DESCRIPTION
Test if the proposed WA in [https://github.com/COPRS/rs-issues/issues/815
[[BUG][L1] PSC_PreprocMain segfault error](https://app.zenhub.com/workspaces/ccb-board-61b0d5b7cccfc20017832c22/issues/gh/coprs/rs-issues/815)](https://github.com/COPRS/rs-issues/issues/815) works

Change the SCDF configuration that overload th dockerfile user:
On OPS EW:  # cat /etc/passwd | grep pic
                      >>>             piccontrol:x:1046:2000::/home/piccontrol:/bin/tcsh
